### PR TITLE
Improve auth middleware JWT handling

### DIFF
--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -1,21 +1,41 @@
 import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
+import jwt, { JwtPayload, Secret } from 'jsonwebtoken';
 import User from '../models/User';
 
-export const authMiddleware = async (req: Request, res: Response, next: NextFunction) => {
+export const authMiddleware = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer')) {
-    return res.status(401).json({ message: 'Authorization token missing or malformed' });
+    return res
+      .status(401)
+      .json({ message: 'Authorization token missing or malformed' });
   }
 
   const token = authHeader.split(' ')[1];
+  if (!token) {
+    return res
+      .status(401)
+      .json({ message: 'Authorization token missing or malformed' });
+  }
+
+  if (!process.env.JWT_SECRET) {
+    // If the secret isn't configured the request can never be authenticated
+    return res.status(500).json({ message: 'JWT secret not configured' });
+  }
 
   try {
-    const decoded: any = jwt.verify(token, process.env.JWT_SECRET!);
-    req.user = await User.findById(decoded.id).select('-password');
-    next();
+    const decoded = jwt.verify(
+      token,
+      process.env.JWT_SECRET as Secret,
+    ) as JwtPayload;
+    const userId = (decoded as any).id;
+    req.user = await User.findById(userId).select('-password');
+    return next();
   } catch (error) {
-    res.status(401).json({ message: 'Token verification failed' });
+    return res.status(401).json({ message: 'Token verification failed' });
   }
 };


### PR DESCRIPTION
## Summary
- ensure JWT secret is configured before verifying tokens
- verify token presence and type correctly for verification

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 1 total)*

------
https://chatgpt.com/codex/tasks/task_e_688e1f448090832fbdae75cc40831d19